### PR TITLE
fix(ProjectImages): allows admins to change the project image

### DIFF
--- a/src/tasks/ProjectImages.js
+++ b/src/tasks/ProjectImages.js
@@ -6,7 +6,7 @@ const set = ({key, values}, uid, {Profiles, Projects, ProjectImages}) =>
     Projects.get(key),
   ])
   .then(([profile,project]) =>
-    isUser(profile, project.ownerProfileKey) &&
+    isUser(profile, project.ownerProfileKey) || isAdmin(profile) &&
       ProjectImages.child(key).set(values) && key
   )
 


### PR DESCRIPTION
Previously the rules would only allow for the Project owner, and _only_ the project owner to set a project image
