### PR TITLE
fix : do-not-check-the-organizer-email-matches-the-invite-email-when-accepting-invites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,6 @@ node_modules
 # Optional REPL history
 .node_repl_history
 
+.idea
+
 dist

--- a/src/tasks/Engagements.js
+++ b/src/tasks/Engagements.js
@@ -169,8 +169,12 @@ function actions({gateway, models}) {
         Engagements.child(key).update({
           isPaid: true,
           isConfirmed: true,
-        }))
-      .then(() => act({role:'Engagements',cmd:'sendEmail',email:'confirmed',key,uid,engagement}))
+        })
+      )
+      .then(() => {
+        // Send the email in the background
+        act({role:'Engagements',cmd:'sendEmail',email:'confirmed',key,uid,engagement})
+      })
       .then(() => respond(null, {key}))
     )
     .catch(err => respond(err))
@@ -193,7 +197,8 @@ function actions({gateway, models}) {
     .then(tap(c => console.log('payment amounts found', c)))
     .then(makePayment({key, values}))
     .then(() => Engagements.get(key))
-    .then(engagement =>
+    .then(engagement => {
+      // Send the email in the background
       act({
         role:'Engagements',
         cmd:'sendEmail',
@@ -201,8 +206,8 @@ function actions({gateway, models}) {
         key,
         uid,
         engagement,
-      }, err => err ? console.error(err) : null)
-    )
+      })
+    })
     .then(() => respond(null, {key}))
     .catch(err => respond(err)))
 

--- a/src/tasks/Engagements.js
+++ b/src/tasks/Engagements.js
@@ -88,7 +88,7 @@ function actions({gateway, models}) {
           cmd:'send',
           email:'engagement',
           templateId:'dec62dab-bf8e-4000-975a-0ef6b264dafe',
-          subject:'Application acceted for',
+          subject:'Application accepted for',
           ...emailInfo,
         }) : null
       )

--- a/src/tasks/Memberships.js
+++ b/src/tasks/Memberships.js
@@ -1,9 +1,10 @@
 function actions({models: {Memberships}, getStuff}) {
-  this.add({role:'Memberships',cmd:'create'}, ({teamKey, oppKey, engagementKey}, respond) => {
+  this.add({role:'Memberships',cmd:'create'}, ({teamKey, oppKey, engagementKey, answer}, respond) => { // eslint-disable-line max-len
     const key = Memberships.push({
       teamKey,
       oppKey,
       engagementKey,
+      answer,
       isApplied: true,
       isAccepted: false,
       isConfirmed: false,

--- a/src/tasks/Opps.js
+++ b/src/tasks/Opps.js
@@ -18,7 +18,7 @@ function actions({auths: {userCanUpdateOpp, userCanUpdateProject}, models: {Enga
               act({
                 role:'email',
                 cmd:'getInfo',
-                key,
+                key: a.$key,
                 profileKey: a.profileKey,
                 uid,
                 oppKey: key,

--- a/src/tasks/Organizers.js
+++ b/src/tasks/Organizers.js
@@ -50,8 +50,7 @@ function actions({auths: {userCanUpdateProject}, models: {Organizers}, getStuff}
     profile &&
     organizer &&
     not(organizer.isAccepted) &&
-    not(organizer.profileKey) &&
-    equals(organizer.inviteEmail, profile.email)
+    not(organizer.profileKey)
 
   const rejectCannotAccept = unless(canAccept, ({profile, organizer}) =>
     Promise.reject(


### PR DESCRIPTION
Reference : 
https://trello.com/c/Mr9nflLf/79-do-not-check-the-organizer-email-matches-the-invite-email-when-accepting-invites
